### PR TITLE
Feat/support composite filter

### DIFF
--- a/src/core/filter.ts
+++ b/src/core/filter.ts
@@ -15,7 +15,7 @@
 // limitations under the License.
 //
 
-import { StructuredQuery_FieldFilter_Operator } from '../proto/db3_database'
+import { StructuredQuery_CompositeFilter_Operator, StructuredQuery_FieldFilter_Operator } from "../proto/db3_database";
 // The operator of a FieldFilter
 export const enum Operator {
     LESS_THAN = '<',
@@ -29,6 +29,11 @@ export const enum Operator {
     NOT_IN = 'not-in',
     ARRAY_CONTAINS_ANY = 'array-contains-any',
 }
+// The operator of a CompositeFilter
+export const enum CompositeOp {
+    AND = 'and',
+    OR = 'or',
+}
 
 export function parseOperator(
     op: Operator
@@ -36,6 +41,31 @@ export function parseOperator(
     switch (op) {
         case Operator.EQUAL: {
             return StructuredQuery_FieldFilter_Operator.EQUAL
+        }
+        case Operator.LESS_THAN: {
+            return StructuredQuery_FieldFilter_Operator.LESS_THAN
+        }
+        case Operator.LESS_THAN_OR_EQUAL: {
+            return StructuredQuery_FieldFilter_Operator.LESS_THAN_OR_EQUAL
+        }
+        case Operator.GREATER_THAN: {
+            return StructuredQuery_FieldFilter_Operator.GREATER_THAN
+        }
+        case Operator.GREATER_THAN_OR_EQUAL: {
+            return StructuredQuery_FieldFilter_Operator.GREATER_THAN_OR_EQUAL
+        }
+        default: {
+            throw new Error('the op is not supported')
+        }
+    }
+}
+
+export function parseCompositeOp(
+  op: CompositeOp
+): StructuredQuery_CompositeFilter_Operator {
+    switch (op) {
+        case CompositeOp.AND: {
+            return StructuredQuery_CompositeFilter_Operator.AND
         }
         default: {
             throw new Error('the op is not supported')

--- a/src/store/query.ts
+++ b/src/store/query.ts
@@ -3,16 +3,17 @@ import type { DocumentReference } from './document'
 import type { CollectionReference } from './collection'
 import type { DocumentData } from '../client/client'
 import {
-    StructuredQuery_FieldFilter,
-    StructuredQuery_Filter,
-} from '../proto/db3_database'
+    StructuredQuery_CompositeFilter,
+    StructuredQuery_FieldFilter, StructuredQuery_FieldFilter_Operator,
+    StructuredQuery_Filter
+} from "../proto/db3_database";
 import {
     Query as InternalQuery,
     parseQueryValue,
     queryWithAddedFilter,
     queryWithLimit,
 } from '../core/query'
-import { Operator, parseOperator } from '../core/filter'
+import { CompositeOp, Operator, parseCompositeOp, parseOperator } from "../core/filter";
 
 export class Query<T = DocumentData> {
     /** The type of this Firestore reference. */
@@ -118,7 +119,6 @@ export class QueryFieldFilterConstraint extends QueryConstraint {
             )
         }
     }
-
     _parse(): StructuredQuery_Filter {
         const filter = newQueryFilter(this._field, this._op, this._value)
         return filter
@@ -162,6 +162,12 @@ export function where(
     return QueryFieldFilterConstraint._create(field, op, value)
 }
 
+export function and(
+  ...queryConstraints: QueryConstraint[]
+): QueryAndConstraint {
+    return QueryAndConstraint._create(queryConstraints)
+}
+
 export function query<T>(
     query: Query<T>,
     ...queryConstraints: QueryConstraint[]
@@ -175,6 +181,57 @@ export function query<T>(
     return query
 }
 
+
+/**
+ * A `QueryAndConstraint` is used to narrow the set of documents returned by
+ * a Firestore query by filtering on one or more document fields.
+ * `QueryFieldFilterConstraint`s are created by invoking {@link where} and can then
+ * be passed to {@link query} to create a new query instance that also contains
+ * this `QueryFieldFilterConstraint`.
+ */
+export class QueryAndConstraint extends QueryConstraint {
+    /** The type of this query constraint */
+    readonly type = 'and'
+
+    /**
+     * @internal
+     */
+    protected constructor(
+      private _filters: QueryConstraint[],
+    ) {
+        super()
+    }
+
+    static _create(
+      _filters: QueryConstraint[],
+    ): QueryAndConstraint {
+        return new QueryAndConstraint(_filters)
+    }
+
+    _apply<T>(query: Query<T>): Query<T> {
+        const filter = this._parse()
+        if (query.type == 'collection') {
+            // convert filters to StructuredQuery_Filter[]
+
+            const internalQuery: InternalQuery<T> = {
+                filters: [filter],
+                limit: null,
+                collection: query as CollectionReference<T>,
+            }
+            return new Query(query.db, internalQuery)
+        } else {
+            return new Query(
+              query.db,
+              queryWithAddedFilter(query._query, filter)
+            )
+        }
+    }
+
+    _parse(): StructuredQuery_Filter {
+        const filter = newCompositeFilter(this._filters, CompositeOp.AND)
+        return filter
+    }
+}
 export class QueryResult<T = DocumentData> {
     readonly docs: Array<DocumentReference<T>>
     readonly db: DB3Store
@@ -206,6 +263,40 @@ function newQueryFilter(
         filterType: {
             oneofKind: 'fieldFilter',
             fieldFilter: filter,
+        },
+    }
+}
+function newCompositeFilter(
+  queryConstraints: QueryConstraint[],
+  op: CompositeOp
+): StructuredQuery_Filter {
+    const filters = []
+    // transform queryConstraints to StructuredQuery_Filter[]
+    for (const constraint of queryConstraints) {
+        // check all queryConstraints are fieldFilter
+        if (constraint.type != 'where') {
+            throw new Error('unsupport filter type')
+        }
+        const filter = (constraint as QueryFieldFilterConstraint)._parse()
+        if (filter.filterType.oneofKind != 'fieldFilter') {
+            throw new Error('unsupport filter type')
+        }
+        if (filter.filterType.fieldFilter.op != StructuredQuery_FieldFilter_Operator.EQUAL) {
+            throw new Error('unsupport where op, required ==')
+        }
+        filters.push(filter)
+    }
+    // const filters = queryConstraints.map(
+    //   (constraint) => (constraint as QueryFieldFilterConstraint)._parse())
+    const queryOp = parseCompositeOp(op)
+    const filter: StructuredQuery_CompositeFilter = {
+        filters: filters,
+        op: queryOp,
+    }
+    return {
+        filterType: {
+            oneofKind: 'compositeFilter',
+            compositeFilter: filter,
         },
     }
 }

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -103,7 +103,7 @@ describe('test db3.js store module', () => {
             text: 'shanghai',
             owner: wallet.getAddress(),
         })
-        await new Promise((r) => setTimeout(r, 1000))
+        await new Promise((r) => setTimeout(r, 2000))
         const docs3 = await getDocs<Todo>(collectionRef)
         expect(docs3.size).toBe(1)
         expect(docs.docs[0].entry.id).toBe(docs3.docs[0].entry.id)

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -33,6 +33,7 @@ import {
 } from '../src/index'
 import { Index, Index_IndexField_Order } from '../src/proto/db3_database'
 import { toHEX } from '../src/crypto/crypto_utils'
+import { and } from "../src/store/query";
 
 interface Todo {
     text: string
@@ -154,7 +155,7 @@ describe('test db3.js store module', () => {
         expect(docs.size).toBe(1)
     })
 
-    test('test document query', async () => {
+    test('test document query with field filter', async () => {
         const client = new DB3Client('http://127.0.0.1:26659', wallet)
         const [dbId, txId] = await client.createDatabase()
         const { db } = initializeDB3('http://127.0.0.1:26659', dbId, wallet)
@@ -169,7 +170,134 @@ describe('test db3.js store module', () => {
                             oneofKind: 'order',
                             order: Index_IndexField_Order.ASCENDING,
                         },
+                    }
+                ],
+
+            },
+            {
+                name: 'idx_name',
+                id: 2,
+                fields: [
+                    {
+                        fieldPath: 'name',
+                        valueMode: {
+                            oneofKind: 'order',
+                            order: Index_IndexField_Order.ASCENDING,
+                        },
+                    }
+                ],
+
+            },
+        ]
+        const collectionRef = await collection<Todo>(db, 'todos', indexList)
+        await new Promise((r) => setTimeout(r, 2000))
+        // create doc
+        const result = await addDoc<Todo>(collectionRef, {
+            text: 'text1',
+            name: 'Bill',
+            owner: wallet.getAddress(),
+        } as Todo)
+
+        await addDoc<Todo>(collectionRef, {
+            text: 'text2',
+            name: 'John',
+            owner: wallet.getAddress(),
+        } as Todo)
+        await addDoc<Todo>(collectionRef, {
+            text: 'text3',
+            name: 'John',
+            owner: wallet.getAddress(),
+        } as Todo)
+        await addDoc<Todo>(collectionRef, {
+            text: 'text4',
+            name: 'Mike',
+            owner: wallet.getAddress(),
+        } as Todo)
+
+        await new Promise((r) => setTimeout(r, 2000))
+        {
+            const docs = await getDocs<Todo>(
+              query<Todo>(
+                collectionRef,
+                where('owner', '==', wallet.getAddress())
+              )
+            )
+            expect(docs.size).toBe(4)
+        }
+        {
+            const docs = await getDocs<Todo>(
+              query<Todo>(collectionRef, where('owner', '==', 'xxx'))
+            )
+            expect(docs.size).toBe(0)
+        }
+
+        {
+            const docs = await getDocs<Todo>(
+              query<Todo>(collectionRef, where('name', '<', 'John'))
+            )
+            expect(docs.size).toBe(1)
+            expect(docs.docs[0].entry.doc.name).toBe('Bill')
+        }
+
+        {
+            const docs = await getDocs<Todo>(
+              query<Todo>(collectionRef, where('name', '<=', 'John'))
+            )
+            expect(docs.size).toBe(3)
+            expect(docs.docs[0].entry.doc.name).toBe('Bill')
+            expect(docs.docs[1].entry.doc.name).toBe('John')
+            expect(docs.docs[2].entry.doc.name).toBe('John')
+        }
+
+        {
+            const docs = await getDocs<Todo>(
+              query<Todo>(collectionRef, where('name', '==', 'John'))
+            )
+            expect(docs.size).toBe(2)
+            expect(docs.docs[0].entry.doc.name).toBe('John')
+            expect(docs.docs[1].entry.doc.name).toBe('John')
+        }
+        {
+            const docs = await getDocs<Todo>(
+              query<Todo>(collectionRef, where('name', '>=', 'John'))
+            )
+            expect(docs.size).toBe(3)
+            expect(docs.docs[0].entry.doc.name).toBe('John')
+            expect(docs.docs[1].entry.doc.name).toBe('John')
+            expect(docs.docs[2].entry.doc.name).toBe('Mike')
+        }
+        {
+            const docs = await getDocs<Todo>(
+              query<Todo>(collectionRef, where('name', '>', 'John'))
+            )
+            expect(docs.size).toBe(1)
+            expect(docs.docs[0].entry.doc.name).toBe('Mike')
+        }
+    })
+
+    test('test document query with composite filter', async () => {
+        const client = new DB3Client('http://127.0.0.1:26659', wallet)
+        const [dbId, txId] = await client.createDatabase()
+        const { db } = initializeDB3('http://127.0.0.1:26659', dbId, wallet)
+        const indexList: Index[] = [
+            {
+                name: 'idx_combine',
+                id: 1,
+                fields: [
+                    {
+                        fieldPath: 'owner',
+                        valueMode: {
+                            oneofKind: 'order',
+                            order: Index_IndexField_Order.ASCENDING,
+                        },
                     },
+                    {
+                        fieldPath: 'name',
+                        valueMode: {
+                            oneofKind: 'order',
+                            order: Index_IndexField_Order.ASCENDING,
+                        },
+                    }
                 ],
             },
         ]
@@ -178,20 +306,56 @@ describe('test db3.js store module', () => {
         // create doc
         const result = await addDoc<Todo>(collectionRef, {
             text: 'text1',
+            name: 'Bill',
+            owner: wallet.getAddress(),
+        } as Todo)
+
+        await addDoc<Todo>(collectionRef, {
+            text: 'text2',
+            name: 'John',
+            owner: wallet.getAddress(),
+        } as Todo)
+        await addDoc<Todo>(collectionRef, {
+            text: 'text3',
+            name: 'John',
             owner: wallet.getAddress(),
         } as Todo)
 
         await new Promise((r) => setTimeout(r, 2000))
         const docs = await getDocs<Todo>(
-            query<Todo>(
-                collectionRef,
-                where('owner', '==', wallet.getAddress())
-            )
+          query<Todo>(
+            collectionRef,
+            and(
+              where('owner', '==', wallet.getAddress()),
+              where('name', '==', 'Bill'))
+          )
         )
         expect(docs.size).toBe(1)
+        expect(docs.docs[0].entry.doc.name).toBe('Bill')
+        expect(docs.docs[0].entry.doc.text).toBe('text1')
+
         const docs2 = await getDocs<Todo>(
-            query<Todo>(collectionRef, where('owner', '==', 'xxx'))
+          query<Todo>(
+            collectionRef,
+            and(
+              where('owner', '==', wallet.getAddress()),
+              where('name', '==', 'John'))
+          )
         )
-        expect(docs2.size).toBe(0)
+        expect(docs2.size).toBe(2)
+        expect(docs2.docs[0].entry.doc.name).toBe('John')
+        expect(docs2.docs[0].entry.doc.text).toBe('text2')
+        expect(docs2.docs[1].entry.doc.name).toBe('John')
+        expect(docs2.docs[1].entry.doc.text).toBe('text3')
+
+        const docs3 = await getDocs<Todo>(
+          query<Todo>(
+            collectionRef,
+            and(
+              where('owner', '==', wallet.getAddress()),
+              where('name', '==', 'Mike'))
+          )
+        )
+        expect(docs3.size).toBe(0)
     })
 })


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/imrtstore/rtstore-tpl/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/imrtstore/rtstore-tpl/blob/main/CHANGELOG.md
-->

Resolve [#423 ](https://github.com/dbpunk-labs/db3/issues/423)
https://github.com/dbpunk-labs/db3.js/issues/56
### Changes
- support filter with multiple field filters in db3.js SDK `and(
              where('owner', '==', wallet.getAddress()),
              where('name', '==', 'John'))
          )`. 
- ONLY support multiple filters with equal conditions.
- ONLY support `and` for composite operator
### Demo
```
const docs2 = await getDocs<Todo>(
          query<Todo>(
            collectionRef,
            and(
              where('owner', '==', wallet.getAddress()),
              where('name', '==', 'John'))
          )
        )
```