### PR TITLE
feat: support create wallet from private key

### DIFF
--- a/src/wallet/db3_browser_wallet.ts
+++ b/src/wallet/db3_browser_wallet.ts
@@ -19,6 +19,8 @@ import type { Wallet, WalletType } from './wallet'
 import { Ed25519Keypair } from '../crypto/ed25519_keypair'
 import { Secp256k1Keypair } from '../crypto/secp256k1_keypair'
 import { fromB64 } from '../crypto/crypto_utils'
+import { fromHEX } from '../crypto/crypto_utils'
+import { toHEX } from '../crypto/crypto_utils'
 
 const WALLET_KEY = '_db3_wallet_key_'
 const WALLET_ADDRESS = '_db3_wallet_ADDR_'
@@ -88,6 +90,25 @@ export class DB3BrowserWallet implements Wallet<Uint8Array, Uint8Array> {
             localStorage.setItem(WALLET_KEY, JSON.stringify(keypair.export()))
             localStorage.setItem(WALLET_ADDRESS, wallet.getAddress())
             return wallet
+        }
+        throw new Error('wallet type is not supported')
+    }
+
+    static createFromPrivateKey(
+        walletType: WalletType,
+        privateKey: string
+    ): DB3BrowserWallet {
+        if (walletType === 'DB3_SECP256K1') {
+            const data = fromHEX(privateKey)
+            const keypair = Secp256k1Keypair.fromSecretKey(data)
+            localStorage.setItem(WALLET_KEY, JSON.stringify(keypair.export()))
+            return new DB3BrowserWallet(keypair, 'DB3_SECP256K1')
+        }
+        if (walletType === 'DB3_ED25519') {
+            const data = fromHEX(privateKey)
+            const keypair = Ed25519Keypair.fromSecretKey(data)
+            localStorage.setItem(WALLET_KEY, JSON.stringify(keypair.export()))
+            return new DB3BrowserWallet(keypair, 'DB3_ED25519')
         }
         throw new Error('wallet type is not supported')
     }

--- a/tests/wallet.test.ts
+++ b/tests/wallet.test.ts
@@ -41,6 +41,30 @@ describe('test db3.js wallet module', () => {
         localStorage.clear()
     })
 
+    test('ed25519 wallet smoke test private key', async () => {
+        const privateKey =
+            'ee394849ac093695ea3c9db6cee14007874a79c118fcb6b8a5684fda4bdc695e685b2d6f98784dd763249af21c92f588ca1be80c40a98c55bf7c91b74e5ac1e2'
+        const wallet = DB3BrowserWallet.createFromPrivateKey(
+            'DB3_ED25519',
+            privateKey
+        )
+        const msg = new Uint8Array(1)
+        msg[0] = 0
+        const signature = wallet.sign(msg)
+        expect(toB64(signature)).toBe(
+            'AGAxggujR0I6p1CFqT4iUlfRs++AgprT4gREHM71+V8qkRktNJRx4WOjudvKGiQUioJ6AU3WC/n1aJjKpa/NXA5oWy1vmHhN12MkmvIckvWIyhvoDECpjFW/fJG3TlrB4g=='
+        )
+        const address = wallet.getAddress()
+        expect(address).toBe('0x1a4623343cd42be47d67314fce0ad042f3c82685')
+        const hasKey = DB3BrowserWallet.hasKey()
+        expect(hasKey).toBe(true)
+        const recoverWallet = DB3BrowserWallet.recover()
+        expect(recoverWallet.getAddress()).toBe(
+            '0x1a4623343cd42be47d67314fce0ad042f3c82685'
+        )
+        localStorage.clear()
+    })
+
     test('secp256k1 wallet smoke test', async () => {
         const mnemonic =
             'result crisp session latin must fruit genuine question prevent start coconut brave speak student dismiss'
@@ -61,6 +85,31 @@ describe('test db3.js wallet module', () => {
         )
         localStorage.clear()
     })
+
+    test('secp256k1 wallet smoke test private key', async () => {
+        const privateKey =
+            'c98f180100bd3ccde3250ae535cdb4346aebc9c2d87636716cb5232380562ca2'
+        const wallet = DB3BrowserWallet.createFromPrivateKey(
+            'DB3_SECP256K1',
+            privateKey
+        )
+        const msg = new Uint8Array(1)
+        msg[0] = 0
+        const signature = wallet.sign(msg)
+        expect(toB64(signature)).toBe(
+            'AX5QFEhl8OQHom8DmzkWJeuPs62q3z7XhAcIUM+MwYnEMoOCA8tB4K4JcEZIqu4vHYu6H4/XHc6Wmn0L0m6TaCsBA+NxdDVYKrM9LjFdIem8ThlQCh/EyM3HOhU2WJF3SxMf'
+        )
+        const address = wallet.getAddress()
+        expect(address).toBe('0xed17b3f435c03ff69c2cdc6d394932e68375f20f')
+        const hasKey = DB3BrowserWallet.hasKey()
+        expect(hasKey).toBe(true)
+        const recoverWallet = DB3BrowserWallet.recover()
+        expect(recoverWallet.getAddress()).toBe(
+            '0xed17b3f435c03ff69c2cdc6d394932e68375f20f'
+        )
+        localStorage.clear()
+    })
+
     test('wallet generate', async () => {
         const wallet = DB3BrowserWallet.generate('DB3_SECP256K1')
         const msg = new Uint8Array(1)


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds support for Ed25519 keypairs to the DB3BrowserWallet class, allowing users to create wallets with this algorithm. It also adds a new static method `createFromPrivateKey` to the class, which allows users to create a wallet from a given private key.

### Detailed summary
- Added support for Ed25519 keypairs to DB3BrowserWallet class
- Added `fromHEX` and `toHEX` methods to `crypto_utils.ts`
- Added `createFromPrivateKey` static method to DB3BrowserWallet class
- Added tests for `createFromPrivateKey` with Ed25519 and secp256k1 keypairs

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->