### PR TITLE
feat: add get gc history

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -37,8 +37,8 @@ export { DB3Network } from './store/network'
 
 export { DB3Account } from './account/db3_account'
 export { MutationHeader } from './proto/db3_mutation_v2'
-export { DatabaseMessage } from './proto/db3_database_v2'
-export { RollupRecord } from './proto/db3_rollup'
+export { DatabaseMessage, Collection } from './proto/db3_database_v2'
+export { RollupRecord, GcRecord } from './proto/db3_rollup'
 export { DB3ClientV2 } from './client/client_v2'
 export {
     createAccountFromPrivateKey,

--- a/src/provider/storage_provider_v2.ts
+++ b/src/provider/storage_provider_v2.ts
@@ -30,6 +30,7 @@ import {
     ScanRollupRecordRequest,
     GetDatabaseOfOwnerRequest,
     GetCollectionOfDatabase,
+    ScanGcRecordRequest,
 } from '../proto/db3_storage'
 import { fromHEX, toHEX } from '../crypto/crypto_utils'
 import { DB3Account } from '../account/db3_account'
@@ -130,6 +131,15 @@ export class StorageProviderV2 {
             limit,
         }
         const { response } = await this.client.scanRollupRecord(request)
+        return response
+    }
+
+    async scanGcRecords(start: number, limit: number) {
+        const request: ScanGcRecordRequest = {
+            start,
+            limit,
+        }
+        const { response } = await this.client.scanGcRecord(request)
         return response
     }
 

--- a/tests/client_v2.test.ts
+++ b/tests/client_v2.test.ts
@@ -105,6 +105,7 @@ describe('test db3.js client module', () => {
                 )
             }
         } catch (e) {
+            console.log(e)
             expect(1).toBe(0)
         }
     })
@@ -115,13 +116,20 @@ describe('test db3.js client module', () => {
             await client.syncNonce()
             const [txId, dbId, block, order] =
                 await client.createSimpleDatabase()
+
             const [txId2, block2, order2] = await client.createCollection(
                 dbId,
                 'collection1',
-                []
+                [
+                    {
+                        name: 'idx1',
+                        fields: ['f1', 'f2'],
+                    },
+                ]
             )
             const collections = await client.getCollectionOfDatabase(dbId)
             expect(1).toBe(collections.length)
+            console.log(collections)
         } catch (e) {
             console.log(e)
             expect(1).toBe(0)


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds new functionality to the `DB3ClientV2` class by introducing the ability to create collections with indexes, and to scan and retrieve garbage collection records. It also includes some minor changes to the `proto` and `storage_provider_v2` files.

### Detailed summary
- Added `CollectionIndex` interface to `client_v2.ts`
- Added `createCollection` method to `DB3ClientV2` class in `client_v2.ts`
- Added `Index_IndexField` and `Index_IndexField_Order` enums to `db3_database_v2.proto`
- Modified `createCollection` method to accept `CollectionIndex` array and convert to `Index` array
- Added `GcRecord` interface to `db3_rollup.proto`
- Added `ScanGcRecordRequest` and `GetCollectionOfDatabaseRequest` interfaces to `db3_storage.proto`
- Added `scanGcRecords` method to `StorageProviderV2` class in `storage_provider_v2.ts`
- Modified `DB3ClientV2` class to include `scanGcRecords` method
- Minor changes to `index.ts` and `client_v2.test.ts` files

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->